### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudfunctions",
     "name_pretty": "Cloud Functions",
     "product_documentation": "https://cloud.google.com/functions/",
-    "client_documentation": "https://googleapis.dev/python/cloudfunctions/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudfunctions/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.