### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudfunctions",
     "name_pretty": "Cloud Functions",
     "product_documentation": "https://cloud.google.com/functions/",
-    "client_documentation": "https://googleapis.dev/python/cloudfunctions/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudfunctions/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Functions
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-functions.svg
    :target: https://pypi.org/project/google-cloud-functions
 .. _Cloud Functions API: https://cloud.google.com/functions/
-.. _Client Library Documentation: https://googleapis.dev/python/cloudfunctions/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudfunctions/latest
 .. _Product Documentation:  https://cloud.google.com/functions/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.